### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/pseudosci/units.py
+++ b/pseudosci/units.py
@@ -49,7 +49,7 @@ class Distance(object):
             self.ly = ly = self.m / LY_M
             return ly
         else:
-            raise AttributeError("No attribute named %r" % (name.lower(),))
+            raise AttributeError("No attribute named {0!r}".format(name.lower()))
 
     def __str__(self):
         return str(self.m)
@@ -155,7 +155,7 @@ class Time(object):
             self.d = d = self.s / D_S
             return d
         else:
-            raise AttributeError("No attribute named %r" % (name.lower(),))
+            raise AttributeError("No attribute named {0!r}".format(name.lower()))
 
     def __str__(self):
         return str(self.s)
@@ -242,7 +242,7 @@ class Velocity(object):
             self.kph = kph = self.mps / KPH_MPS
             return kph
         else:
-            raise AttributeError("No attribute named %r" % (name.lower(),))
+            raise AttributeError("No attribute named {0!r}".format(name.lower()))
 
     def __str__(self):
         return str(self.mps)
@@ -338,7 +338,7 @@ class Acceleration(object):
             self.kphs = kphs = self.mpss / KPHS_MPSS
             return kphs
         else:
-            raise AttributeError("No attribute named %r" % (name.lower(),))
+            raise AttributeError("No attribute named {0!r}".format(name.lower()))
 
     def __str__(self):
         return str(self.mpss)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:Lucidiot:PseudoScience?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:Lucidiot:PseudoScience?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)