### PR TITLE
Problème de métaclasses.

### DIFF
--- a/pseudosci/units/__init__.py
+++ b/pseudosci/units/__init__.py
@@ -4,9 +4,6 @@
 l'unité du système international."""
 
 
-from six import with_metaclass
-
-
 class UnitBase(type):
     """Métaclasse servant à la création d'unités."""
     units = {}
@@ -182,6 +179,6 @@ class UnitBase(type):
             UnitBase.units[cls.__name__] = cls
 
 
-class Unit(with_metaclass(UnitBase)):
+class Unit(object):
     """Classe abstraite d'unité de base."""
     __metaclass__ = UnitBase


### PR DESCRIPTION
Dans Visual Studio Code, la découverte de tests unitaires échoue avec with_metaclass.
Après l'expérimentation, il s'avère que le problème a également lieu avec les builds Travis CI. Le test sans with_metaclass est concluant.