### PR TITLE
Fix des puissances

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -8,6 +8,12 @@
             "command": "python -m pytest --cov ${workspaceRoot}/pseudosci",
             "type": "shell",
             "problemMatcher": []
+        },
+        {
+            "label": "Rapport HTML de couverture des tests",
+            "command": "python -m pytest --cov ${workspaceRoot}/pseudosci --cov-report html",
+            "type": "shell",
+            "problemMatcher": []
         }
     ]
 }

--- a/pseudosci/relativity.py
+++ b/pseudosci/relativity.py
@@ -8,7 +8,7 @@ from .movement import Movement
 
 
 def contraction_factor(vel):
-    return sqrt(1 - (vel ** 2) / (LIGHT_VELOCITY ** 2))
+    return sqrt(1 - (vel.value ** 2) / (LIGHT_VELOCITY.value ** 2))
 
 
 def lorentz_factor(vel):

--- a/pseudosci/units/__init__.py
+++ b/pseudosci/units/__init__.py
@@ -145,9 +145,13 @@ class UnitBase(type):
             return NotImplemented
 
         def _pow(self, other):
-            if isinstance(other, (int, float)):
-                return type(self)(value=self.value ** other)
-            return NotImplemented
+            if not isinstance(other, int):
+                return NotImplemented
+            if other > 1:  # [1, infinity]
+                return self ** (other - 1) * self
+            elif other < 0:  # [-infinity, 0]
+                return (1 / self) ** abs(other)
+            return 1 if other == 0 else self  # [0, 1]
 
         def _eq(self, other):
             if type(self) is type(other):

--- a/pseudosci/units/general.py
+++ b/pseudosci/units/general.py
@@ -271,6 +271,7 @@ class Momentum(Unit):
     divide = {'Mass': 'Velocity', 'Velocity': 'Mass', 'Force': 'Time',
               'Time': 'Force'}
 
+
 class SurfaceTension(Unit):
     """Décrit une force par distance (N.m^-1), ou M.T^-2. L'unité
     correspondante du système international est le newton par mètre.\n

--- a/pseudosci/units/tests/test_unit.py
+++ b/pseudosci/units/tests/test_unit.py
@@ -74,6 +74,7 @@ class TestUnit:
         assert (UnitOne(value=5) // 2).value == 2.0
         assert (UnitOne(value=7.5) / UnitOne(value=2.5)) == 3.0
         assert (UnitOne(value=7.5) // UnitOne(value=2)) == 3.0
+        assert (UnitTwo(value=2) ** -1).value == 0.5
         assert (1 / UnitTwo(value=2)).value == 0.5
         assert (1 // UnitTwo(value=2)).value == 0
         assert int(UnitOne(value=23.4)) == 23


### PR DESCRIPTION
Règle le problème des puissances mal implémentées. Nouvelles règles de puissances :

* Impossible de faire une puissance avec un nombre non entier ;
* Toute unité puissance zéro donne 1 ;
* Toute unité puissance 1 donne cette unité ;
* Toute unité puissance -1 donne l'inverse de l'unité ;
* Toute unité puissance `x` positif donne la multiplication de cette unité par elle-même `x` fois ;
* Toute unité puissance `-x` négatif donne l'inverse de l'unité puissance `x`.